### PR TITLE
setting txId in manifest while downloading its data

### DIFF
--- a/src/__tests__/providers-registry.contract.spec.ts
+++ b/src/__tests__/providers-registry.contract.spec.ts
@@ -813,7 +813,8 @@ describe("Provider Registry Contract", () => {
           "status": "active",
           "manifestTxId": "700_6",
           "activeManifestContent": {
-            "foo": "bar"
+            "foo": "bar",
+            "txId": "700_6"
           }
         }
       });

--- a/src/providers-registry/providers-registry.contract.ts
+++ b/src/providers-registry/providers-registry.contract.ts
@@ -244,6 +244,7 @@ export async function handle(state: ProvidersRegistryState, action: ProvidersReg
         manifest.manifestTxId,
         {decode: true, string: true});
       manifest.activeManifestContent = JSON.parse(manifestContent);
+      manifest.activeManifestContent.txId = manifest.manifestTxId;
     } catch (e) {
       trace("Error while fetching manifest", e);
     }


### PR DESCRIPTION
already deployed on Arweave, can be verified with `node src/tools/providers-registry.api.js currentManifest I-5rWUehEv-MjdK9gFw09RxfSLQX9DIHxG614Wf8qo0 false`